### PR TITLE
MuseScore.download: update web regex for https DMG url

### DIFF
--- a/MuseScore/MuseScore.download.recipe
+++ b/MuseScore/MuseScore.download.recipe
@@ -24,7 +24,7 @@
                 <key>url</key>
                 <string>https://musescore.org/en/download/musescore.dmg</string>
                 <key>re_pattern</key>
-                <string>(?P&lt;url&gt;http://ftp\..*\..*/pub/musescore/releases/MuseScore-(?P&lt;version&gt;[0-9.]*)/MuseScore-[0-9.]*\.dmg)</string>
+                <string>(?P&lt;url&gt;https://ftp\..*\..*/pub/musescore/releases/MuseScore-(?P&lt;version&gt;[0-9.]*)/MuseScore-[0-9.]*\.dmg)</string>
             </dict>
         </dict>
         <dict>


### PR DESCRIPTION
Looks like with MuseScore 2.1 they've moved the download URL to HTTPS. Doesn't seem like any other changes are needed.