### PR TITLE
Remove NAME variable from app paths

### DIFF
--- a/Boinx/iStopMotion3.pkg.recipe
+++ b/Boinx/iStopMotion3.pkg.recipe
@@ -47,7 +47,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>info_path</key>
-				<string>%pkgroot%/Applications/%NAME%.app</string>
+				<string>%pkgroot%/Applications/iStopMotion.app</string>
 				<key>plist_keys</key>
 				<dict>
 					<key>CFBundleIdentifier</key>

--- a/Hamrick/VueScanLicenced.pkg.recipe
+++ b/Hamrick/VueScanLicenced.pkg.recipe
@@ -8,7 +8,7 @@ This recipe requires the hansen-m-recipes (Matt Hansen) repo.
 
 The recipe requires the authorization file created by VueScan for your licence.
 The suggested way to do this is to install VueScan on the Mac/VM running AutoPkg and use the recipe's
-default value for RC_FILE. Alternately, you can create a text file made up of the following four lines 
+default value for RC_FILE. Alternately, you can create a text file made up of the following four lines
 (where you replace # with the values for your license):
 
 [VueScan]
@@ -16,7 +16,7 @@ SerialNumber=#
 CustomerNumber=#
 EmailAddress=#@#.#
 
-Then, save that file in a locally-accessible location and set the RC_FILE input variable to 
+Then, save that file in a locally-accessible location and set the RC_FILE input variable to
 the path to that file (including the file name with extension). AutoPkg will do the rest.</string>
     <key>Identifier</key>
     <string>com.github.jazzace.pkg.VueScanLicenced</string>
@@ -68,7 +68,7 @@ the path to that file (including the file name with extension). AutoPkg will do 
                 <key>source_path</key>
                 <string>%pathname%/*.app</string>
                 <key>destination_path</key>
-                <string>%pkgroot%/Applications/%NAME%.app</string>
+                <string>%pkgroot%/Applications/VueScan.app</string>
             </dict>
         </dict>
         <dict>

--- a/Hexler/TouchOSCEditor.download.recipe
+++ b/Hexler/TouchOSCEditor.download.recipe
@@ -59,7 +59,7 @@ In order to check the Code Signature, the Zip archive is expanded.</string>
             <key>Arguments</key>
             <dict>
                 <key>input_path</key>
-                <string>%RECIPE_CACHE_DIR%/Unarchived/touchosc-editor-%versn%-osx/%NAME%.app</string>
+                <string>%RECIPE_CACHE_DIR%/Unarchived/touchosc-editor-%versn%-osx/TouchOSC Editor.app</string>
                 <key>requirement</key>
                 <string>identifier "net.hexler.TouchOSCEditor" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = "784FHWRMF9"</string>
             </dict>

--- a/Hexler/TouchOSCEditor.pkg.recipe
+++ b/Hexler/TouchOSCEditor.pkg.recipe
@@ -20,7 +20,7 @@
             <key>Arguments</key>
             <dict>
                 <key>app_path</key>
-                <string>%RECIPE_CACHE_DIR%/Unarchived/touchosc-editor-%versn%-osx/%NAME%.app</string>
+                <string>%RECIPE_CACHE_DIR%/Unarchived/touchosc-editor-%versn%-osx/TouchOSC Editor.app</string>
                 <key>overwrite</key>
                 <true/>
             </dict>

--- a/Processing/Processing.pkg.recipe
+++ b/Processing/Processing.pkg.recipe
@@ -47,7 +47,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>info_path</key>
-				<string>%pkgroot%/Applications/%NAME%.app</string>
+				<string>%pkgroot%/Applications/Processing.app</string>
 				<key>plist_keys</key>
 				<dict>
 					<key>CFBundleIdentifier</key>


### PR DESCRIPTION
Because variables can be overridden, it's a good idea to make sure that the recipe will still work even if a non-default variables used. One issue that would prevent recipes from running is using a `NAME` variable in paths that should be hard-coded (e.g. `/Applications/Foo.app`).

This PR removes the `NAME` variable from all file paths and replaces it with the actual app name, which should make the recipe more resilient for overrides.