### PR TITLE
Add EndOfCheckPhase processor

### DIFF
--- a/MakeMusic/FinaleUpdate.download.recipe
+++ b/MakeMusic/FinaleUpdate.download.recipe
@@ -33,6 +33,10 @@
                 <string>%NAME%.zip</string>
             </dict>
         </dict>
+        <dict>
+            <key>Processor</key>
+            <string>EndOfCheckPhase</string>
+        </dict>
     </array>
 </dict>
 </plist>


### PR DESCRIPTION
The EndOfCheckPhase processor allows administrators to use `autopkg run --check`, which is typically used to check for newly available software versions but not process any subsequent steps. It's typical to include the EndOfCheckPhase processor in most .download recipes.