### PR TITLE
Update MuseScore.download.recipe

### DIFF
--- a/MuseScore/MuseScore.download.recipe
+++ b/MuseScore/MuseScore.download.recipe
@@ -16,17 +16,20 @@
 	<key>Process</key>
 	<array>
 		<dict>
-			<key>Processor</key>
-			<string>GitHubReleasesInfoProvider</string>
 			<key>Arguments</key>
 			<dict>
-				<key>asset_regex</key>
-				<string>MuseScore-[\.\d]+\.dmg</string>
-				<key>github_repo</key>
-				<string>musescore/MuseScore</string>
+				<key>appcast_url</key>
+				<string>https://sparkle.musescore.org/stable/3/macos/appcast.xml</string>
 			</dict>
+			<key>Processor</key>
+			<string>SparkleUpdateInfoProvider</string>
 		</dict>
 		<dict>
+			<key>Arguments</key>
+			<dict>
+				<key>filename</key>
+				<string>%NAME%-%version%.dmg</string>
+			</dict>
 			<key>Processor</key>
 			<string>URLDownloader</string>
 		</dict>


### PR DESCRIPTION
Use Sparkle feed to include additional version info.

MuseScore developers are using the same release tag on github while still iterating the app version.  For instance:

SparkleUpdateInfoProvider: Version retrieved from appcast: 3.5.2.312126096

where the github processor will only see the 3.5.2 release tag.