### PR TITLE
Adjust PkgCreator arguments

### DIFF
--- a/Boinx/iStopMotion3.pkg.recipe
+++ b/Boinx/iStopMotion3.pkg.recipe
@@ -92,9 +92,9 @@ Expect this recipe to be removed at a future date.</string>
 					<string>purge_ds_store</string>
 					<key>pkgdir</key>
 					<string>%RECIPE_CACHE_DIR%</string>
+					<key>pkgname</key>
+					<string>%NAME%-%version%</string>
 				</dict>
-				<key>pkgname</key>
-				<string>%NAME%-%version%</string>
 			</dict>
 		</dict>
 	</array>

--- a/Hamrick/VueScanLicenced.pkg.recipe
+++ b/Hamrick/VueScanLicenced.pkg.recipe
@@ -122,9 +122,9 @@ the path to that file (including the file name with extension). AutoPkg will do 
 					<string>purge_ds_store</string>
 					<key>pkgdir</key>
 					<string>%RECIPE_CACHE_DIR%</string>
+					<key>pkgname</key>
+					<string>%NAME%-%version%</string>
 				</dict>
-				<key>pkgname</key>
-				<string>%NAME%-%version%</string>
 			</dict>
 		</dict>
 	</array>

--- a/Processing/Processing.pkg.recipe
+++ b/Processing/Processing.pkg.recipe
@@ -81,9 +81,9 @@
 					<string>purge_ds_store</string>
 					<key>pkgdir</key>
 					<string>%RECIPE_CACHE_DIR%</string>
+					<key>pkgname</key>
+					<string>%NAME%-%version%</string>
 				</dict>
-				<key>pkgname</key>
-				<string>%NAME%-%version%</string>
 			</dict>
 		</dict>
 	</array>


### PR DESCRIPTION
`pkgname` is [intended](https://github.com/autopkg/autopkg/blob/e36d5cba2823dbdfcb69a41a38b1aef9fb76121c/Code/autopkgserver/autopkgserver#L47) to be in the `pkg_request` dictionary, not as a standalone argument for [PkgCreator](https://github.com/autopkg/autopkg/wiki/Processor-PkgCreator).