### PR TITLE
Adjust AppPkgCreator arguments

### DIFF
--- a/Hexler/TouchOSCEditor.pkg.recipe
+++ b/Hexler/TouchOSCEditor.pkg.recipe
@@ -21,8 +21,6 @@
 			<dict>
 				<key>app_path</key>
 				<string>%RECIPE_CACHE_DIR%/Unarchived/touchosc-editor-%version%-macos/TouchOSC Editor.app</string>
-				<key>overwrite</key>
-				<true/>
 			</dict>
 		</dict>
 	</array>


### PR DESCRIPTION
`overwrite` is not a valid [AppPkgCreator](https://github.com/autopkg/autopkg/wiki/Processor-AppPkgCreator) argument.