### PR TITLE
Adjust PkgCopier arguments

### DIFF
--- a/Mozilla/FirefoxSignedPkg.ds.recipe
+++ b/Mozilla/FirefoxSignedPkg.ds.recipe
@@ -42,8 +42,6 @@ Input key:
                 <string>%pathname%</string>
                 <key>pkg_path</key>
                 <string>%DS_PKGS_PATH%/%NAME%-%version%.pkg</string>
-                <key>overwrite</key>
-                <true/>
             </dict>
         </dict>
     </array>


### PR DESCRIPTION
`overwrite` is not a valid input variable for [PkgCopier](https://github.com/autopkg/autopkg/wiki/Processor-PkgCopier), and has no effect here.