### PR TITLE
Fix MinimumVersion key

### DIFF
--- a/ClipGrab.org/ClipGrabMac.download.recipe
+++ b/ClipGrab.org/ClipGrabMac.download.recipe
@@ -13,7 +13,7 @@
 		<key>os</key>
 		<string>dmg</string>
 	</dict>
-	<key>MiniumumVersion</key>
+	<key>MinimumVersion</key>
 	<string>1.0</string>
 	<key>ParentRecipe</key>
 	<string>com.github.peshay.download.ClipGrab</string>

--- a/ClipGrab.org/ClipGrabMac.pkg.recipe
+++ b/ClipGrab.org/ClipGrabMac.pkg.recipe
@@ -8,7 +8,7 @@
 	<string>com.github.jazzace.pkg.ClipGrabMac</string>
 	<key>Input</key>
 	<dict/>
-	<key>MiniumumVersion</key>
+	<key>MinimumVersion</key>
 	<string>1.0</string>
 	<key>ParentRecipe</key>
 	<string>com.github.jazzace.download.ClipGrabMac</string>

--- a/HairerSoft/AmadeusLite.pkg.recipe
+++ b/HairerSoft/AmadeusLite.pkg.recipe
@@ -8,7 +8,7 @@
 	<string>com.github.jazzace.pkg.AmadeusLite</string>
 	<key>Input</key>
 	<dict/>
-	<key>MiniumumVersion</key>
+	<key>MinimumVersion</key>
 	<string>1.0.0</string>
 	<key>ParentRecipe</key>
 	<string>com.github.jazzace.download.AmadeusLite</string>

--- a/HairerSoft/AmadeusPro.pkg.recipe
+++ b/HairerSoft/AmadeusPro.pkg.recipe
@@ -8,7 +8,7 @@
 	<string>com.github.jazzace.pkg.AmadeusPro</string>
 	<key>Input</key>
 	<dict/>
-	<key>MiniumumVersion</key>
+	<key>MinimumVersion</key>
 	<string>1.0.0</string>
 	<key>ParentRecipe</key>
 	<string>com.github.jazzace.download.AmadeusPro</string>

--- a/MakeMusic/Finale_NoGarritan.pkg.recipe
+++ b/MakeMusic/Finale_NoGarritan.pkg.recipe
@@ -22,7 +22,7 @@ https://makemusic.zendesk.com/hc/en-us/articles/115007423647-Commands-to-silentl
 		<key>NAME</key>
 		<string>Finale</string>
 	</dict>
-	<key>MiniumumVersion</key>
+	<key>MinimumVersion</key>
 	<string>1.4</string>
 	<key>Process</key>
 	<array>

--- a/Nemetschek/Vectorworks.pkg.recipe
+++ b/Nemetschek/Vectorworks.pkg.recipe
@@ -26,7 +26,7 @@ If you need Vectorworks 2020, use the Vectorworks2020.pkg recipe.
 		<key>VW_SERIAL_NO</key>
 		<string>GFXXXX-123456-ABCDEF-G7HI89</string>
 	</dict>
-	<key>MiniumumVersion</key>
+	<key>MinimumVersion</key>
 	<string>1.4</string>
 	<key>ParentRecipe</key>
 	<string>com.github.jazzace.download.vectorworks</string>

--- a/Nemetschek/VectorworksLogin.pkg.recipe
+++ b/Nemetschek/VectorworksLogin.pkg.recipe
@@ -26,7 +26,7 @@ Quit. You will find the file at ~/Library/Application Support/Vectorworks/20##/S
 		<key>VW_SERIES</key>
 		<string>G</string>
 	</dict>
-	<key>MiniumumVersion</key>
+	<key>MinimumVersion</key>
 	<string>1.4</string>
 	<key>Process</key>
 	<array>

--- a/Pixologic/ZBrushVolume.pkg.recipe
+++ b/Pixologic/ZBrushVolume.pkg.recipe
@@ -33,7 +33,7 @@ look something like this:
 		<key>ZSCRIPT_FILE</key>
 		<string>/path/to/DefaultZScript.txt</string>
 	</dict>
-	<key>MiniumumVersion</key>
+	<key>MinimumVersion</key>
 	<string>1.4</string>
 	<key>Process</key>
 	<array>

--- a/Sassafras/SassafrasAdmin.install.recipe
+++ b/Sassafras/SassafrasAdmin.install.recipe
@@ -11,7 +11,7 @@
 		<key>NAME</key>
 		<string>AllSight</string>
 	</dict>
-	<key>MiniumumVersion</key>
+	<key>MinimumVersion</key>
 	<string>1.4</string>
 	<key>ParentRecipe</key>
 	<string>com.github.jazzace.download.sassafrasadmin</string>


### PR DESCRIPTION
A typo was [found and fixed](https://github.com/autopkg/autopkg/commit/983087f63d49c8dbc4dbbd6bb5ced34321c59ac6) in the template AutoPkg uses when the `autopkg new-recipe` command is used. This PR makes the same change in your recipes that are affected by the typo.