### PR TITLE
Update KB number and Expected Authority Name

### DIFF
--- a/AppleProVideo/ProVideoFormats.download.recipe
+++ b/AppleProVideo/ProVideoFormats.download.recipe
@@ -30,7 +30,7 @@ This recipe supports Version 2.1 and later (requires macOS 10.14.3 or later).
 			<key>Arguments</key>
 			<dict>
 				<key>ARTICLE_NUMBER</key>
-				<string>2050</string>
+				<string>2100</string>
 			</dict>
 		</dict>
 		<dict>
@@ -48,7 +48,7 @@ This recipe supports Version 2.1 and later (requires macOS 10.14.3 or later).
 			<dict>
 				<key>expected_authority_names</key>
 				<array>
-					<string>Development Update</string>
+					<string>Software Update</string>
 					<string>Apple Software Update Certification Authority</string>
 					<string>Apple Root CA</string>
 				</array>


### PR DESCRIPTION
The KB article number for ProVideoFormats has changed:

https://support.apple.com/kb/DL2100?locale=en_GB

Furthermore, I encountered an issue with the `expected_authority_names`:

```
CodeSignatureVerifier: Mismatch in authority names
CodeSignatureVerifier: Expected: Development Update -> Apple Software Update Certification Authority -> Apple Root CA
CodeSignatureVerifier: Found:    Software Update -> Apple Software Update Certification Authority -> Apple Root CA
Mismatch in authority names. Note that all verification can be disabled by setting the variable DISABLE_CODE_SIGNATURE_VERIFICATION to a non-empty value.
Failed.
```

I've updated both accordingly and the changed recipe ran successfully for me.