### PR TITLE
Update KeyShot recipes for version 12

### DIFF
--- a/Luxion/KeyShot.download.recipe
+++ b/Luxion/KeyShot.download.recipe
@@ -21,7 +21,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>re_pattern</key>
-				<string>https://download\.keyshot\.com/keyshot\d{4}/keyshot_mac64_[\d._]+\.pkg</string>
+				<string>(https://www\.keyshot\.com/download/357619/\?tmstv=\d+)</string>
 				<key>result_output_var_name</key>
 				<string>url</string>
 				<key>url</key>

--- a/Luxion/KeyShot.pkg.recipe
+++ b/Luxion/KeyShot.pkg.recipe
@@ -11,7 +11,7 @@ for KS_VERSION.</string>
 	<key>Input</key>
 	<dict>
 		<key>KS_VERSION</key>
-		<string>11</string>
+		<string>12</string>
 	</dict>
 	<key>MinimumVersion</key>
 	<string>2.0</string>


### PR DESCRIPTION
Resolves https://github.com/autopkg/jazzace-recipes/issues/35.

```
% autopkg run -vv Luxion/KeyShot.download.recipe
Processing Luxion/KeyShot.download.recipe...
WARNING: Luxion/KeyShot.download.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
URLTextSearcher
{'Input': {'re_pattern': '(https://www\\.keyshot\\.com/download/357619/\\?tmstv=\\d+)',
           'result_output_var_name': 'url',
           'url': 'https://www.keyshot.com/resources/downloads/'}}
URLTextSearcher: Found matching text (url): https://www.keyshot.com/download/357619/?tmstv=1687817414
{'Output': {'url': 'https://www.keyshot.com/download/357619/?tmstv=1687817414'}}
URLDownloader
{'Input': {'prefetch_filename': True,
           'url': 'https://www.keyshot.com/download/357619/?tmstv=1687817414'}}
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Filename prefetched from the HTTP Location header: keyshot_mac64_2023.1_12.0.0.186.pkg
URLDownloader: Item at URL is unchanged.
URLDownloader: Using existing ~/Library/AutoPkg/Cache/com.github.jazzace.download.keyshot/downloads/keyshot_mac64_2023.1_12.0.0.186.pkg
{'Output': {'pathname': '~/Library/AutoPkg/Cache/com.github.jazzace.download.keyshot/downloads/keyshot_mac64_2023.1_12.0.0.186.pkg'}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
CodeSignatureVerifier
{'Input': {'expected_authority_names': ['Developer ID Installer: Luxion, Inc '
                                        '(W7B24M74T3)',
                                        'Developer ID Certification Authority',
                                        'Apple Root CA'],
           'input_path': '~/Library/AutoPkg/Cache/com.github.jazzace.download.keyshot/downloads/keyshot_mac64_2023.1_12.0.0.186.pkg'}}
CodeSignatureVerifier: Verifying installer package signature...
CodeSignatureVerifier: Package "keyshot_mac64_2023.1_12.0.0.186.pkg":
CodeSignatureVerifier:    Status: signed by a developer certificate issued by Apple for distribution
CodeSignatureVerifier:    Notarization: trusted by the Apple notary service
CodeSignatureVerifier:    Signed with a trusted timestamp on: 2023-03-13 10:03:06 +0000
CodeSignatureVerifier:    Certificate Chain:
CodeSignatureVerifier:     1. Developer ID Installer: Luxion, Inc (W7B24M74T3)
CodeSignatureVerifier:        Expires: 2024-07-31 08:17:34 +0000
CodeSignatureVerifier:        SHA256 Fingerprint:
CodeSignatureVerifier:            82 BD 4C C5 1A 7A 7C B3 90 D4 BF E7 54 B2 43 24 ED 92 89 A1 1C 63 
CodeSignatureVerifier:            17 39 98 0F BF C6 23 72 D2 E8
CodeSignatureVerifier:        ------------------------------------------------------------------------
CodeSignatureVerifier:     2. Developer ID Certification Authority
CodeSignatureVerifier:        Expires: 2027-02-01 22:12:15 +0000
CodeSignatureVerifier:        SHA256 Fingerprint:
CodeSignatureVerifier:            7A FC 9D 01 A6 2F 03 A2 DE 96 37 93 6D 4A FE 68 09 0D 2D E1 8D 03 
CodeSignatureVerifier:            F2 9C 88 CF B0 B1 BA 63 58 7F
CodeSignatureVerifier:        ------------------------------------------------------------------------
CodeSignatureVerifier:     3. Apple Root CA
CodeSignatureVerifier:        Expires: 2035-02-09 21:40:36 +0000
CodeSignatureVerifier:        SHA256 Fingerprint:
CodeSignatureVerifier:            B0 B1 73 0E CB C7 FF 45 05 14 2C 49 F1 29 5E 6E DA 6B CA ED 7E 2C 
CodeSignatureVerifier:            68 C5 BE 91 B5 A1 10 01 F0 24
CodeSignatureVerifier: 
CodeSignatureVerifier: Signature is valid
CodeSignatureVerifier: Authority name chain is valid
{'Output': {}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.jazzace.download.keyshot/receipts/KeyShot.download-receipt-20230627-063836.plist

Nothing downloaded, packaged or imported.

% autopkg run -vv Luxion/KeyShot.pkg.recipe -p ~/Library/AutoPkg/Cache/com.github.jazzace.download.keyshot/downloads/keyshot_mac64_2023.1_12.0.0.186.pkg
Processing Luxion/KeyShot.pkg.recipe...
WARNING: Luxion/KeyShot.pkg.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
URLTextSearcher
{'Input': {'re_pattern': '(https://www\\.keyshot\\.com/download/357619/\\?tmstv=\\d+)',
           'result_output_var_name': 'url',
           'url': 'https://www.keyshot.com/resources/downloads/'}}
URLTextSearcher: Found matching text (url): https://www.keyshot.com/download/357619/?tmstv=1687817414
{'Output': {'url': 'https://www.keyshot.com/download/357619/?tmstv=1687817414'}}
URLDownloader
{'Input': {'PKG': '~/Library/AutoPkg/Cache/com.github.jazzace.download.keyshot/downloads/keyshot_mac64_2023.1_12.0.0.186.pkg',
           'prefetch_filename': True,
           'url': 'https://www.keyshot.com/download/357619/?tmstv=1687817414'}}
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Given ~/Library/AutoPkg/Cache/com.github.jazzace.download.keyshot/downloads/keyshot_mac64_2023.1_12.0.0.186.pkg, no download needed.
{'Output': {'download_changed': True,
            'pathname': '~/Library/AutoPkg/Cache/com.github.jazzace.download.keyshot/downloads/keyshot_mac64_2023.1_12.0.0.186.pkg'}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
CodeSignatureVerifier
{'Input': {'expected_authority_names': ['Developer ID Installer: Luxion, Inc '
                                        '(W7B24M74T3)',
                                        'Developer ID Certification Authority',
                                        'Apple Root CA'],
           'input_path': '~/Library/AutoPkg/Cache/com.github.jazzace.download.keyshot/downloads/keyshot_mac64_2023.1_12.0.0.186.pkg'}}
CodeSignatureVerifier: Verifying installer package signature...
CodeSignatureVerifier: Package "keyshot_mac64_2023.1_12.0.0.186.pkg":
CodeSignatureVerifier:    Status: signed by a developer certificate issued by Apple for distribution
CodeSignatureVerifier:    Notarization: trusted by the Apple notary service
CodeSignatureVerifier:    Signed with a trusted timestamp on: 2023-03-13 10:03:06 +0000
CodeSignatureVerifier:    Certificate Chain:
CodeSignatureVerifier:     1. Developer ID Installer: Luxion, Inc (W7B24M74T3)
CodeSignatureVerifier:        Expires: 2024-07-31 08:17:34 +0000
CodeSignatureVerifier:        SHA256 Fingerprint:
CodeSignatureVerifier:            82 BD 4C C5 1A 7A 7C B3 90 D4 BF E7 54 B2 43 24 ED 92 89 A1 1C 63 
CodeSignatureVerifier:            17 39 98 0F BF C6 23 72 D2 E8
CodeSignatureVerifier:        ------------------------------------------------------------------------
CodeSignatureVerifier:     2. Developer ID Certification Authority
CodeSignatureVerifier:        Expires: 2027-02-01 22:12:15 +0000
CodeSignatureVerifier:        SHA256 Fingerprint:
CodeSignatureVerifier:            7A FC 9D 01 A6 2F 03 A2 DE 96 37 93 6D 4A FE 68 09 0D 2D E1 8D 03 
CodeSignatureVerifier:            F2 9C 88 CF B0 B1 BA 63 58 7F
CodeSignatureVerifier:        ------------------------------------------------------------------------
CodeSignatureVerifier:     3. Apple Root CA
CodeSignatureVerifier:        Expires: 2035-02-09 21:40:36 +0000
CodeSignatureVerifier:        SHA256 Fingerprint:
CodeSignatureVerifier:            B0 B1 73 0E CB C7 FF 45 05 14 2C 49 F1 29 5E 6E DA 6B CA ED 7E 2C 
CodeSignatureVerifier:            68 C5 BE 91 B5 A1 10 01 F0 24
CodeSignatureVerifier: 
CodeSignatureVerifier: Signature is valid
CodeSignatureVerifier: Authority name chain is valid
{'Output': {}}
FlatPkgUnpacker
{'Input': {'destination_path': '~/Library/AutoPkg/Cache/com.github.jazzace.pkg.keyshot/unpack',
           'flat_pkg_path': '~/Library/AutoPkg/Cache/com.github.jazzace.download.keyshot/downloads/keyshot_mac64_2023.1_12.0.0.186.pkg'}}
FlatPkgUnpacker: Unpacked ~/Library/AutoPkg/Cache/com.github.jazzace.download.keyshot/downloads/keyshot_mac64_2023.1_12.0.0.186.pkg to ~/Library/AutoPkg/Cache/com.github.jazzace.pkg.keyshot/unpack
{'Output': {}}
FileFinder
{'Input': {'pattern': '~/Library/AutoPkg/Cache/com.github.jazzace.pkg.keyshot/unpack/*KeyShot_App/Payload'}}
FileFinder: No value supplied for find_method, setting default value of: glob
FileFinder: Found file match: '~/Library/AutoPkg/Cache/com.github.jazzace.pkg.keyshot/unpack/5._KeyShot_App/Payload' from globbed '~/Library/AutoPkg/Cache/com.github.jazzace.pkg.keyshot/unpack/*KeyShot_App/Payload'
FileFinder: Basename match: 'Payload'
{'Output': {'found_basename': 'Payload',
            'found_filename': '~/Library/AutoPkg/Cache/com.github.jazzace.pkg.keyshot/unpack/5._KeyShot_App/Payload'}}
PkgPayloadUnpacker
{'Input': {'destination_path': '~/Library/AutoPkg/Cache/com.github.jazzace.pkg.keyshot/payload',
           'pkg_payload_path': '~/Library/AutoPkg/Cache/com.github.jazzace.pkg.keyshot/unpack/5._KeyShot_App/Payload'}}
PkgPayloadUnpacker: Unpacked ~/Library/AutoPkg/Cache/com.github.jazzace.pkg.keyshot/unpack/5._KeyShot_App/Payload to ~/Library/AutoPkg/Cache/com.github.jazzace.pkg.keyshot/payload
{'Output': {}}
Versioner
{'Input': {'input_plist_path': '~/Library/AutoPkg/Cache/com.github.jazzace.pkg.keyshot/payload/KeyShot12.app/Contents/Info.plist',
           'plist_version_key': 'CFBundleVersion'}}
Versioner: No value supplied for skip_single_root_dir, setting default value of: False
Versioner: Found version 12.0.0 in file ~/Library/AutoPkg/Cache/com.github.jazzace.pkg.keyshot/payload/KeyShot12.app/Contents/Info.plist
{'Output': {'version': '12.0.0'}}
PathDeleter
{'Input': {'path_list': ['~/Library/AutoPkg/Cache/com.github.jazzace.pkg.keyshot/unpack',
                         '~/Library/AutoPkg/Cache/com.github.jazzace.pkg.keyshot/payload']}}
PathDeleter: Deleted ~/Library/AutoPkg/Cache/com.github.jazzace.pkg.keyshot/unpack
PathDeleter: Deleted ~/Library/AutoPkg/Cache/com.github.jazzace.pkg.keyshot/payload
{'Output': {}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.jazzace.pkg.keyshot/receipts/KeyShot.pkg-receipt-20230627-063859.plist

Nothing downloaded, packaged or imported.
```