### PR TITLE
Update Processing4.download.recipe

### DIFF
--- a/Processing Foundation/Processing4.download.recipe
+++ b/Processing Foundation/Processing4.download.recipe
@@ -59,7 +59,7 @@ If you want the Intel-only app, change ARCHITECTURE to x64.</string>
 				<key>input_path</key>
 				<string>%RECIPE_CACHE_DIR%/%NAME%/Processing.app</string>
 				<key>requirement</key>
-				<string>identifier "org.processing.four" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = "8SBRM6J77J"</string>
+				<string>identifier "org.processing.app" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = "6297K33652"</string>
 			</dict>
 		</dict>
 	</array>


### PR DESCRIPTION
CodeSignatureVerifier changes:
App bundle identifier changed to "org.processing.app" Certificate Team ID changed to "6297K33652"