### PR TITLE
Update download method for SpectraViewII M1 Build

### DIFF
--- a/NEC/SpectraViewII-AS.download.recipe
+++ b/NEC/SpectraViewII-AS.download.recipe
@@ -19,7 +19,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>re_pattern</key>
-				<string>https:\/\/update\.sharpnecdisplays\.us\/spectraview\/NEC_SpectraViewII_MacOS_v[\d\.]+_Mac_M1_Special_Build\.dmg</string>
+				<string>href="(//update\.sharpnecdisplays\.us/spectraview/nec_spectraviewii_macos_v[\d\.]+_mac_m1_special_build\.dmg)"</string>
 				<key>url</key>
 				<string>https://www.sharpnecdisplays.us/support-and-services/spectraviewii/4</string>
 			</dict>
@@ -32,7 +32,7 @@
 				<key>filename</key>
 				<string>%NAME%.dmg</string>
 				<key>url</key>
-				<string>%match%</string>
+				<string>https:%match%</string>
 			</dict>
 			<key>Processor</key>
 			<string>URLDownloader</string>


### PR DESCRIPTION
This PR updates the download method for the M1 "special build" of the NEC SpectraViewII software.

Verbose recipe run output:

```
% autopkg run -vvq 'NEC/SpectraViewII-AS.download.recipe'
Processing NEC/SpectraViewII-AS.download.recipe...
WARNING: NEC/SpectraViewII-AS.download.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
URLTextSearcher
{'Input': {'re_pattern': 'href="(//update\\.sharpnecdisplays\\.us/spectraview/nec_spectraviewii_macos_v[\\d\\.]+_mac_m1_special_build\\.dmg)"',
           'url': 'https://www.sharpnecdisplays.us/support-and-services/spectraviewii/4'}}
URLTextSearcher: No value supplied for result_output_var_name, setting default value of: match
URLTextSearcher: Found matching text (match): //update.sharpnecdisplays.us/spectraview/nec_spectraviewii_macos_v1.1.42_mac_m1_special_build.dmg
{'Output': {'match': '//update.sharpnecdisplays.us/spectraview/nec_spectraviewii_macos_v1.1.42_mac_m1_special_build.dmg'}}
URLDownloader
{'Input': {'filename': 'SpectraViewII-M1.dmg',
           'url': 'https://update.sharpnecdisplays.us/spectraview/nec_spectraviewii_macos_v1.1.42_mac_m1_special_build.dmg'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Storing new Last-Modified header: Wed, 10 Jul 2024 21:04:39 GMT
URLDownloader: Storing new ETag header: 0x8DCA123E9C02930
URLDownloader: Downloaded ~/Library/AutoPkg/Cache/com.github.jazzace.download.SpectraViewII-M1/downloads/SpectraViewII-M1.dmg
{'Output': {'download_changed': True,
            'etag': '0x8DCA123E9C02930',
            'last_modified': 'Wed, 10 Jul 2024 21:04:39 GMT',
            'pathname': '~/Library/AutoPkg/Cache/com.github.jazzace.download.SpectraViewII-M1/downloads/SpectraViewII-M1.dmg',
            'url_downloader_summary_result': {'data': {'download_path': '~/Library/AutoPkg/Cache/com.github.jazzace.download.SpectraViewII-M1/downloads/SpectraViewII-M1.dmg'},
                                              'summary_text': 'The following '
                                                              'new items were '
                                                              'downloaded:'}}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
CodeSignatureVerifier
{'Input': {'input_path': '~/Library/AutoPkg/Cache/com.github.jazzace.download.SpectraViewII-M1/downloads/SpectraViewII-M1.dmg/SpectraView '
                         'II.app',
           'requirement': 'identifier "com.necdisplay.SpectraViewII" and '
                          'anchor apple generic and certificate '
                          '1[field.1.2.840.113635.100.6.2.6] /* exists */ and '
                          'certificate leaf[field.1.2.840.113635.100.6.1.13] '
                          '/* exists */ and certificate leaf[subject.OU] = '
                          '"77XL9RA8Q5"'}}
CodeSignatureVerifier: Mounted disk image ~/Library/AutoPkg/Cache/com.github.jazzace.download.SpectraViewII-M1/downloads/SpectraViewII-M1.dmg
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification not defined. Using codesign defaults...
CodeSignatureVerifier: /private/tmp/dmg.7AkRuK/SpectraView II.app: valid on disk
CodeSignatureVerifier: /private/tmp/dmg.7AkRuK/SpectraView II.app: satisfies its Designated Requirement
CodeSignatureVerifier: /private/tmp/dmg.7AkRuK/SpectraView II.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
{'Output': {}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.jazzace.download.SpectraViewII-M1/receipts/SpectraViewII-AS.download-receipt-20241226-185808.plist

The following new items were downloaded:
    Download Path
    -------------
    ~/Library/AutoPkg/Cache/com.github.jazzace.download.SpectraViewII-M1/downloads/SpectraViewII-M1.dmg
```

