### PR TITLE
Fix KeyShot recipes

### DIFF
--- a/Luxion/KeyShot.download.recipe
+++ b/Luxion/KeyShot.download.recipe
@@ -35,8 +35,8 @@ using the same principles.
 			<string>URLDownloader</string>
 			<key>Arguments</key>
 			<dict>
-				<key>prefetch_filename</key>
-				<true/>
+				<key>filename</key>
+				<string>%NAME%.pkg</string>
 				<key>url</key>
 				<string>https://www.keyshot.com/download/%PRODUCT_ID%/</string>
 			</dict>


### PR DESCRIPTION
This PR adjusts the download arguments for KeyShot. It appears that the `prefetch_filename` argument isn't working, and the resulting filename can't be parsed by CodeSignatureVerifier as a result. Manually specifying a filename resolves this.

Verbose recipe run output:

```
% autopkg run -vvq 'Luxion/KeyShot.download.recipe'
Processing Luxion/KeyShot.download.recipe...
WARNING: Luxion/KeyShot.download.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
URLDownloader
{'Input': {'filename': 'KeyShot.pkg',
           'url': 'https://www.keyshot.com/download/370762/'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Storing new Last-Modified header: Tue, 10 Dec 2024 09:39:32 GMT
URLDownloader: Storing new ETag header: "555a35c6a9f1112b6fc56dfc89613743-88"
URLDownloader: Downloaded ~/Library/AutoPkg/Cache/com.github.jazzace.download.keyshot/downloads/KeyShot.pkg
{'Output': {'download_changed': True,
            'etag': '"555a35c6a9f1112b6fc56dfc89613743-88"',
            'last_modified': 'Tue, 10 Dec 2024 09:39:32 GMT',
            'pathname': '~/Library/AutoPkg/Cache/com.github.jazzace.download.keyshot/downloads/KeyShot.pkg',
            'url_downloader_summary_result': {'data': {'download_path': '~/Library/AutoPkg/Cache/com.github.jazzace.download.keyshot/downloads/KeyShot.pkg'},
                                              'summary_text': 'The following '
                                                              'new items were '
                                                              'downloaded:'}}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
CodeSignatureVerifier
{'Input': {'expected_authority_names': ['Developer ID Installer: Luxion, Inc '
                                        '(W7B24M74T3)',
                                        'Developer ID Certification Authority',
                                        'Apple Root CA'],
           'input_path': '~/Library/AutoPkg/Cache/com.github.jazzace.download.keyshot/downloads/KeyShot.pkg'}}
CodeSignatureVerifier: Verifying installer package signature...
CodeSignatureVerifier: Package "KeyShot.pkg":
CodeSignatureVerifier:    Status: signed by a developer certificate issued by Apple for distribution
CodeSignatureVerifier:    Notarization: trusted by the Apple notary service
CodeSignatureVerifier:    Signed with a trusted timestamp on: 2024-12-05 12:41:36 +0000
CodeSignatureVerifier:    Certificate Chain:
CodeSignatureVerifier:     1. Developer ID Installer: Luxion, Inc (W7B24M74T3)
CodeSignatureVerifier:        Expires: 2029-07-05 08:05:01 +0000
CodeSignatureVerifier:        SHA256 Fingerprint:
CodeSignatureVerifier:            D1 89 72 EC 2F FD 4B 96 C6 9B 19 E9 5A E2 DC BF 74 8D C4 15 4D E5
CodeSignatureVerifier:            54 A2 E4 0E 2E C4 6A 19 51 1E
CodeSignatureVerifier:        ------------------------------------------------------------------------
CodeSignatureVerifier:     2. Developer ID Certification Authority
CodeSignatureVerifier:        Expires: 2031-09-17 00:00:00 +0000
CodeSignatureVerifier:        SHA256 Fingerprint:
CodeSignatureVerifier:            F1 6C D3 C5 4C 7F 83 CE A4 BF 1A 3E 6A 08 19 C8 AA A8 E4 A1 52 8F
CodeSignatureVerifier:            D1 44 71 5F 35 06 43 D2 DF 3A
CodeSignatureVerifier:        ------------------------------------------------------------------------
CodeSignatureVerifier:     3. Apple Root CA
CodeSignatureVerifier:        Expires: 2035-02-09 21:40:36 +0000
CodeSignatureVerifier:        SHA256 Fingerprint:
CodeSignatureVerifier:            B0 B1 73 0E CB C7 FF 45 05 14 2C 49 F1 29 5E 6E DA 6B CA ED 7E 2C
CodeSignatureVerifier:            68 C5 BE 91 B5 A1 10 01 F0 24
CodeSignatureVerifier:
CodeSignatureVerifier: Signature is valid
CodeSignatureVerifier: Authority name chain is valid
{'Output': {}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.jazzace.download.keyshot/receipts/KeyShot.download-receipt-20241226-184828.plist

The following new items were downloaded:
    Download Path
    -------------
    ~/Library/AutoPkg/Cache/com.github.jazzace.download.keyshot/downloads/KeyShot.pkg
```