### PR TITLE
WIP : Add custom processor to download Vectorworks Update file

### DIFF
--- a/Nemetschek/VectorworksInstallManager.download.recipe
+++ b/Nemetschek/VectorworksInstallManager.download.recipe
@@ -66,6 +66,8 @@ Note that this recipe only works for Vectorworks 2025 and later (use Vectorworks
 			<dict>
 				<key>install_manager_path</key>
 				<string>%RECIPE_CACHE_DIR%/Unarchived/Vectorworks %MAJOR_VERSION% Install Manager.app</string>
+				<key>major_version</key>
+				<string>%MAJOR_VERSION%</string>
 			</dict>
 		</dict>
 	</array>

--- a/Nemetschek/VectorworksInstallManager.download.recipe
+++ b/Nemetschek/VectorworksInstallManager.download.recipe
@@ -59,6 +59,15 @@ Note that this recipe only works for Vectorworks 2025 and later (use Vectorworks
 				<string>identifier "net.vectorworks.%MAJOR_VERSION%.vectorworksinstallmanager" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = LFNG3Q6WX2</string>
 			</dict>
 		</dict>
+		<dict>
+			<key>Processor</key>
+			<string>VectorworksUpdateDownloader</string>
+			<key>Arguments</key>
+			<dict>
+				<key>install_manager_path</key>
+				<string>%RECIPE_CACHE_DIR%/Unarchived/Vectorworks %MAJOR_VERSION% Install Manager.app</string>
+			</dict>
+		</dict>
 	</array>
 </dict>
 </plist>

--- a/Nemetschek/VectorworksUpdateDownloader.py
+++ b/Nemetschek/VectorworksUpdateDownloader.py
@@ -17,6 +17,10 @@ class VectorworksUpdateDownloader(Processor):
 
     description = __doc__
     input_variables = {
+        "major_version": {
+            "required": True,
+            "description": "Major version of Vectoworks i.e. 2025.",
+        },
         "install_manager_path": {
             "required": True,
             "description": "Path to the install manager app.",
@@ -50,7 +54,7 @@ class VectorworksUpdateDownloader(Processor):
             update_target_version = "Update" + high_version
             self.output("Found update target %s" % update_target_version)
 
-            update_dir = self.env["RECIPE_CACHE_DIR"] + "/Update"
+            update_dir = self.env["RECIPE_CACHE_DIR"] + "/Update/" + self.env["major_version"]
             update_download_command = [downloader_cli,
                         'download',
                         '--target',

--- a/Nemetschek/VectorworksUpdateDownloader.py
+++ b/Nemetschek/VectorworksUpdateDownloader.py
@@ -1,0 +1,80 @@
+#!/usr/local/autopkg/python
+
+
+from __future__ import absolute_import
+
+import os
+import subprocess
+
+from autopkglib import Processor, ProcessorError
+
+__all__ = ["VectorworksUpdateDownloader"]
+
+
+class VectorworksUpdateDownloader(Processor):
+    """This processor uses the Vectorworks Installation Manager app 
+    to download the Uodate file used for offline installs"""
+
+    description = __doc__
+    input_variables = {
+        "install_manager_path": {
+            "required": True,
+            "description": "Path to the install manager app.",
+        }
+    }
+    output_variables = {
+        "downloaded_update_path": {"description": "Outputs path to the update file."}
+    }
+
+    def main(self):
+        try:
+            downloader_cli = self.env["install_manager_path"] + "/Contents/Resources/cli.sh"
+            list_updates_command = [downloader_cli,
+                            'download',
+                            '--ls']
+            self.output("Running command : %s" % list_updates_command)
+            process = subprocess.run(
+                   list_updates_command,
+                   stdout=subprocess.PIPE,
+                   stderr=subprocess.PIPE,
+                   text=True)
+            List = process.stdout.strip()
+
+            high_version = "0"
+            for line in List.split("\n"):
+                if "Update" in line:
+                    version = line[10:]
+                    if version > high_version:
+                        high_version = version
+
+            update_target_version = "Update" + high_version
+            self.output("Found update target %s" % update_target_version)
+
+            update_dir = self.env["RECIPE_CACHE_DIR"] + "/Update"
+            update_download_command = [downloader_cli,
+                        'download',
+                        '--target',
+                        update_target_version,
+                        '--dest',
+                        update_dir]
+            download_update_path = update_dir + '/' + update_target_version + '.vwim'
+
+            if not os.path.isfile(download_update_path):
+                self.output("Running command  %s" % update_download_command)
+                process = subprocess.run(
+                        update_download_command,
+                        stdout=subprocess.PIPE,
+                        stderr=subprocess.PIPE,
+                        text=True)
+            else:
+                self.output("Update already exists as : %s" % download_update_path)
+            self.env["downloaded_update_path"] = download_update_path 
+
+        except Exception as err:
+            # handle unexpected errors here
+            raise ProcessorError(err)
+
+
+if __name__ == "__main__":
+    PROCESSOR = VectorworksUpdateDownloader()
+    PROCESSOR.execute_shell()


### PR DESCRIPTION
Consider this a work in progress.  I took a crack at a custom processor that used the Install Manager App CLI to first list available "Updates" and then download the latest.  

I added the extra step to the `.download` recipe, but what if the admin only wants to download the Install Manager app and NOT the update?   Thoughts : 
1.  Add another recipe that uses the existing download recipe as a parent. 
2.  Add a boolean input to decide whether to proceed with the download of the update.
3.  Leave it all in the download recipe like I have it in the current iteration of the PR