### PR TITLE
Add FindAndReplace processor to AppleSupportContent.download

### DIFF
--- a/AppleProVideo/AppleSupportContent.download.recipe
+++ b/AppleProVideo/AppleSupportContent.download.recipe
@@ -49,6 +49,24 @@ This is functionally meant to replace Nate Felton’s AppleSupportDownloadInfoPr
 			</dict>
 		</dict>
 		<dict>
+			<key>Arguments</key>
+			<dict>
+				<key>find</key>
+				<string> </string>
+				<key>input_string</key>
+				<string>%url%</string>
+				<key>replace</key>
+				<string></string>
+			</dict>
+			<key>Processor</key>
+			<string>com.github.homebysix.FindAndReplace/FindAndReplace</string>
+		</dict>
+		<dict>
+			<key>Arguments</key>
+			<dict>
+				<key>url</key>
+				<string>%output_string%</string>
+			</dict>
 			<key>Processor</key>
 			<string>URLDownloader</string>
 		</dict>


### PR DESCRIPTION
Stripping away any errant spaces that Apple for whatever reason has in the URL.

Fixes #45. 