### PR TITLE
Update all available URLs from HTTP to HTTPS

### DIFF
--- a/MakeMusic/Finale.download.recipe
+++ b/MakeMusic/Finale.download.recipe
@@ -38,7 +38,7 @@ Tested with Versions 26 and 27 (specify the major version you want in FINALE_VER
 			<key>Arguments</key>
 			<dict>
 				<key>url</key>
-				<string>http://makemusic-downloads.makemusic.com/Finale/%version%/Mac/en-US/FinaleSetup.dmg</string>
+				<string>https://makemusic-downloads.makemusic.com/Finale/%version%/Mac/en-US/FinaleSetup.dmg</string>
 			</dict>
 		</dict>
 		<dict>


### PR DESCRIPTION
It's important to use HTTPS for downloading software whenever possible in order to avoid the possibility of person-in-the-middle attacks (like the one that affected the Sparkle update framework [back in 2016](https://vulnsec.com/2016/osx-apps-vulnerabilities/)).

For this pull request, I detected and changed to HTTPS URLs automatically using my [HTTPS Spotter](https://www.elliotjordan.com/posts/autopkg-https/) script, and then tested all changed recipes manually to ensure exit codes of recipe run remains the same before/after the change.

Thanks for considering!

_This PR was submitted using [Repo Lasso](https://github.com/homebysix/repo-lasso) v1.2.0._