### PR TITLE
Removal of unused `options` from PkgCreator arguments

### DIFF
--- a/AUTOMATIC1111/StableDiffusionWebUI.pkg.recipe
+++ b/AUTOMATIC1111/StableDiffusionWebUI.pkg.recipe
@@ -53,8 +53,6 @@ AUTOMATIC1111 GitHub project and builds a package that deploys it to /Users/Shar
 				<dict>
 					<key>id</key>
 					<string>com.github.AUTOMATIC1111.StableDiffusionWebUI</string>
-					<key>options</key>
-					<string>purge_ds_store</string>
 					<key>pkgname</key>
 					<string>%NAME%-%version%</string>
 					<key>pkgroot</key>

--- a/Ableton/AbletonLiveSassafras.pkg.recipe
+++ b/Ableton/AbletonLiveSassafras.pkg.recipe
@@ -124,8 +124,6 @@ echo '-_DisableAutoUpdates' >> "/Library/Preferences/Ableton/Live %version%/Opti
 					</array>
 					<key>id</key>
 					<string>%bundleid%-sassafras</string>
-					<key>options</key>
-					<string>purge_ds_store</string>
 					<key>pkgname</key>
 					<string>%NAME%-%version%</string>
 					<key>pkgroot</key>

--- a/AdobeUninstaller/AdobeUninstaller.pkg.recipe
+++ b/AdobeUninstaller/AdobeUninstaller.pkg.recipe
@@ -120,8 +120,6 @@ This recipe requires the homebysix-recipes repo.</string>
 					</array>
 					<key>id</key>
 					<string>com.adobe.PDApp.CCP.AdobeUninstaller</string>
-					<key>options</key>
-					<string>purge_ds_store</string>
 					<key>pkgname</key>
 					<string>%NAME%-%version%</string>
 					<key>pkgroot</key>

--- a/GardenGnome/Pano2VRVolume.pkg.recipe
+++ b/GardenGnome/Pano2VRVolume.pkg.recipe
@@ -153,8 +153,6 @@ your preference.
 					</array>
 					<key>id</key>
 					<string>%bundleid%volume</string>
-					<key>options</key>
-					<string>purge_ds_store</string>
 					<key>pkgname</key>
 					<string>%NAME%-%version%</string>
 					<key>pkgroot</key>

--- a/Hamrick/VueScanLicenced.pkg.recipe
+++ b/Hamrick/VueScanLicenced.pkg.recipe
@@ -118,8 +118,6 @@ the path to that file (including the file name with extension). AutoPkg will do 
 					</array>
 					<key>id</key>
 					<string>%PKG_ID%</string>
-					<key>options</key>
-					<string>purge_ds_store</string>
 					<key>pkgdir</key>
 					<string>%RECIPE_CACHE_DIR%</string>
 					<key>pkgname</key>

--- a/JamfProTools/JamfSetComputerName.pkg.recipe
+++ b/JamfProTools/JamfSetComputerName.pkg.recipe
@@ -89,8 +89,6 @@ rm "${NAMES_CSV}"
 				<dict>
 					<key>id</key>
 					<string>%REVERSE_DOMAIN%.%NAME%</string>
-					<key>options</key>
-					<string>purge_ds_store</string>
 					<key>pkgname</key>
 					<string>%NAME%-%version%</string>
 					<key>pkgroot</key>

--- a/JazzAce/DisplayCalibrationSupportFiles.pkg.recipe
+++ b/JazzAce/DisplayCalibrationSupportFiles.pkg.recipe
@@ -217,8 +217,6 @@ in my jazzace-recipes repo for an example of using StringSplitter to grab the fi
 					</array>
 					<key>id</key>
 					<string>%BUNDLE_ID%</string>
-					<key>options</key>
-					<string>purge_ds_store</string>
 					<key>pkgname</key>
 					<string>%PKG_NAME%-%PKG_VERSION%</string>
 					<key>pkgroot</key>

--- a/JazzAce/OutsetLoginOverridePkgReqd.pkg.recipe
+++ b/JazzAce/OutsetLoginOverridePkgReqd.pkg.recipe
@@ -208,8 +208,6 @@ It is recommended that you change this value in your override to match your orga
 					</array>
 					<key>id</key>
 					<string>%REVERSE_DOMAIN%.%output_string%</string>
-					<key>options</key>
-					<string>purge_ds_store</string>
 					<key>pkgdir</key>
 					<string>%RECIPE_CACHE_DIR%</string>
 					<key>scripts</key>

--- a/JazzAce/OutsetPayloadPkgReqd.pkg.recipe
+++ b/JazzAce/OutsetPayloadPkgReqd.pkg.recipe
@@ -185,8 +185,6 @@ It is recommended that you change this value in your override to match your orga
 					</array>
 					<key>id</key>
 					<string>%REVERSE_DOMAIN%.%output_string%</string>
-					<key>options</key>
-					<string>purge_ds_store</string>
 					<key>pkgdir</key>
 					<string>%RECIPE_CACHE_DIR%</string>
 				</dict>

--- a/MakeMusic/FinaleNoGarritan.pkg.recipe
+++ b/MakeMusic/FinaleNoGarritan.pkg.recipe
@@ -166,8 +166,6 @@ fi
 					</array>
 					<key>id</key>
 					<string>com.makemusic.finale.%version%.custom</string>
-					<key>options</key>
-					<string>purge_ds_store</string>
 					<key>pkgname</key>
 					<string>%NAME%-%version%</string>
 					<key>pkgroot</key>

--- a/MakeMusic/FinaleNoGarritanFromDMG.pkg.recipe
+++ b/MakeMusic/FinaleNoGarritanFromDMG.pkg.recipe
@@ -187,8 +187,6 @@ fi
 					</array>
 					<key>id</key>
 					<string>com.makemusic.finale.%version%.custom</string>
-					<key>options</key>
-					<string>purge_ds_store</string>
 					<key>pkgname</key>
 					<string>%NAME%-%version%</string>
 					<key>pkgroot</key>

--- a/Maxon/ZBrushMaxon.pkg.recipe
+++ b/Maxon/ZBrushMaxon.pkg.recipe
@@ -105,8 +105,6 @@ exit 0
 				<dict>
 					<key>id</key>
 					<string>%BUNDLE_ID%</string>
-					<key>options</key>
-					<string>purge_ds_store</string>
 					<key>pkgname</key>
 					<string>%NAME%-%version%</string>
 					<key>pkgroot</key>

--- a/Maxon/ZBrushMaxonNoZHomePage.pkg.recipe
+++ b/Maxon/ZBrushMaxonNoZHomePage.pkg.recipe
@@ -200,8 +200,6 @@ exit 0
 					</array>
 					<key>id</key>
 					<string>%BUNDLE_ID%</string>
-					<key>options</key>
-					<string>purge_ds_store</string>
 					<key>pkgname</key>
 					<string>%NAME%-%version%</string>
 					<key>pkgroot</key>

--- a/Nemetschek/Vectorworks2024.pkg.recipe
+++ b/Nemetschek/Vectorworks2024.pkg.recipe
@@ -141,8 +141,6 @@ fi
 					</array>
 					<key>id</key>
 					<string>%bundleid%custom</string>
-					<key>options</key>
-					<string>purge_ds_store</string>
 					<key>pkgname</key>
 					<string>%NAME%-%version%</string>
 					<key>pkgroot</key>

--- a/Nemetschek/VectorworksInstallManager.pkg.recipe
+++ b/Nemetschek/VectorworksInstallManager.pkg.recipe
@@ -119,8 +119,6 @@ fi
 				<dict>
 					<key>id</key>
 					<string>%BUNDLE_ID%</string>
-					<key>options</key>
-					<string>purge_ds_store</string>
 					<key>pkgname</key>
 					<string>%NAME%-%version%</string>
 					<key>scripts</key>

--- a/Nemetschek/VectorworksInstallManagerWithServer.pkg.recipe
+++ b/Nemetschek/VectorworksInstallManagerWithServer.pkg.recipe
@@ -238,8 +238,6 @@ fi
 					</array>
 					<key>id</key>
 					<string>%BUNDLE_ID%</string>
-					<key>options</key>
-					<string>purge_ds_store</string>
 					<key>pkgname</key>
 					<string>%NAME%-%version%</string>
 					<key>pkgroot</key>

--- a/Nemetschek/VectorworksLogin.pkg.recipe
+++ b/Nemetschek/VectorworksLogin.pkg.recipe
@@ -127,8 +127,6 @@ cp "${loginxml}" "${targetdir}"
 					</array>
 					<key>id</key>
 					<string>net.nemetschek.vectorworks.%MAJOR_VERSION%.logindialog</string>
-					<key>options</key>
-					<string>purge_ds_store</string>
 					<key>pkgname</key>
 					<string>%NAME%-%MAJOR_VERSION%</string>
 					<key>pkgroot</key>

--- a/Nemetschek/VectorworksWithServer2024.pkg.recipe
+++ b/Nemetschek/VectorworksWithServer2024.pkg.recipe
@@ -280,8 +280,6 @@ fi
 					</array>
 					<key>id</key>
 					<string>%bundleid%custom</string>
-					<key>options</key>
-					<string>purge_ds_store</string>
 					<key>pkgname</key>
 					<string>%NAME%-%version%</string>
 					<key>pkgroot</key>

--- a/NewHouseInternetServices/PTGuiVolume.pkg.recipe
+++ b/NewHouseInternetServices/PTGuiVolume.pkg.recipe
@@ -133,8 +133,6 @@ Your command to create the pkg will look something like this:
 					</array>
 					<key>id</key>
 					<string>%bundleid%.%NAME%</string>
-					<key>options</key>
-					<string>purge_ds_store</string>
 					<key>pkgname</key>
 					<string>%NAME%-%version%</string>
 					<key>pkgroot</key>

--- a/Pixologic/ZBrushVolume.pkg.recipe
+++ b/Pixologic/ZBrushVolume.pkg.recipe
@@ -221,8 +221,6 @@ exit 0
 					</array>
 					<key>id</key>
 					<string>%bundleid%.%NAME%</string>
-					<key>options</key>
-					<string>purge_ds_store</string>
 					<key>pkgname</key>
 					<string>%NAME%-%output_string%</string>
 					<key>pkgroot</key>

--- a/Processing Foundation/Processing.pkg.recipe
+++ b/Processing Foundation/Processing.pkg.recipe
@@ -77,8 +77,6 @@
 					</array>
 					<key>id</key>
 					<string>%bundleid%</string>
-					<key>options</key>
-					<string>purge_ds_store</string>
 					<key>pkgdir</key>
 					<string>%RECIPE_CACHE_DIR%</string>
 					<key>pkgname</key>

--- a/Tim Sutton/customdisplayprofiles.pkg.recipe
+++ b/Tim Sutton/customdisplayprofiles.pkg.recipe
@@ -68,8 +68,6 @@ that deploys it to /usr/local/bin.</string>
 					</array>
 					<key>id</key>
 					<string>com.github.timsutton.customdisplayprofiles%ARCHITECTURE%</string>
-					<key>options</key>
-					<string>purge_ds_store</string>
 					<key>pkgname</key>
 					<string>%NAME%-%ARCHITECTURE%-%version%</string>
 					<key>pkgroot</key>

--- a/Wacom/WacomEnterpriseSettings.pkg.recipe
+++ b/Wacom/WacomEnterpriseSettings.pkg.recipe
@@ -83,8 +83,6 @@ but you may change this in your override or using the -k option at runtime.
 					</array>
 					<key>id</key>
 					<string>%PACKAGE_BUNDLE_ID%</string>
-					<key>options</key>
-					<string>purge_ds_store</string>
 					<key>pkgname</key>
 					<string>%NAME%-%version%</string>
 					<key>pkgroot</key>


### PR DESCRIPTION
Hundreds of recipes dating from the very beginning of AutoPkg use the `options` key in the `pkg_request` argument of PkgCreator:

```xml
<key>options</key>
<string>purge_ds_store</string>
```

However, this key doesn't serve any purpose at all. The `options` key is ignored and not passed along to `pkgbuild`, regardless of its presence or contents. It appears that this has been the case since the very first public release of AutoPkg 0.1.0!

So this pull request (one of over 100) formally ends this practice and removes the unused and unneeded `options` key from all recipes in the AutoPkg org that use PkgCreator.

Thanks for considering!

_This PR was submitted using [Repo Lasso](https://github.com/homebysix/repo-lasso) v1.2.0._