### PR TITLE
Move `pkgname` key into `pkg_request` dictionary of PkgCreator arguments

### DIFF
--- a/JazzAce/OutsetLoginOverridePkgReqd.pkg.recipe
+++ b/JazzAce/OutsetLoginOverridePkgReqd.pkg.recipe
@@ -212,9 +212,9 @@ It is recommended that you change this value in your override to match your orga
 					<string>%RECIPE_CACHE_DIR%</string>
 					<key>scripts</key>
 					<string>%RECIPE_CACHE_DIR%/scripts</string>
+					<key>pkgname</key>
+					<string>%name_no_ext%-%version%</string>
 				</dict>
-				<key>pkgname</key>
-				<string>%name_no_ext%-%version%</string>
 			</dict>
 		</dict>
 		<dict>

--- a/JazzAce/OutsetPayloadPkgReqd.pkg.recipe
+++ b/JazzAce/OutsetPayloadPkgReqd.pkg.recipe
@@ -187,9 +187,9 @@ It is recommended that you change this value in your override to match your orga
 					<string>%REVERSE_DOMAIN%.%output_string%</string>
 					<key>pkgdir</key>
 					<string>%RECIPE_CACHE_DIR%</string>
+					<key>pkgname</key>
+					<string>%name_no_ext%-%version%</string>
 				</dict>
-				<key>pkgname</key>
-				<string>%name_no_ext%-%version%</string>
 			</dict>
 		</dict>
 		<dict>


### PR DESCRIPTION
Although `pkgname` can technically live anywhere within the AutoPkg recipe since it can be read from the environment, it's conventional to put it where it's directly accessed: in the `pkg_request` dictionary alongside `version`, `id`, and other keys.

This PR makes that adjustment. Thanks for considering!

_Submitted using [Repo Lasso](https://github.com/homebysix/repo-lasso) v1.3.0._