### PR TITLE
Deprecate MeshLabPreRelease

### DIFF
--- a/MeshLab/MeshLabPreRelease.download.recipe
+++ b/MeshLab/MeshLabPreRelease.download.recipe
@@ -12,9 +12,18 @@
 		<string>MeshLab</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>1.0.0</string>
+	<string>1.1</string>
 	<key>Process</key>
 	<array>
+        <dict>
+            <key>Processor</key>
+            <string>DeprecationWarning</string>
+            <key>Arguments</key>
+            <dict>
+                <key>warning_message</key>
+                <string>Consider switching to the MeshLab recipes elsewhere in this repo, with INCLUDE_PRERELEASES set to a non-empty value to retrieve pre-release versions of MeshLab. This recipe is deprecated and will be removed in the future.</string>
+            </dict>
+        </dict>
 		<dict>
 			<key>Processor</key>
 			<string>GitHubReleasesInfoProvider</string>


### PR DESCRIPTION
Download recipe in hansen-m-recipes can retrieve prereleases.