### PR TITLE
Change Processing4 parent recipe

### DIFF
--- a/Processing Foundation/Processing4.download.recipe
+++ b/Processing Foundation/Processing4.download.recipe
@@ -19,6 +19,15 @@ If you want the Intel-only app, change ARCHITECTURE to x64.</string>
 	<string>2.0</string>
 	<key>Process</key>
 	<array>
+        <dict>
+            <key>Processor</key>
+            <string>DeprecationWarning</string>
+            <key>Arguments</key>
+            <dict>
+                <key>warning_message</key>
+                <string>Consider switching to the Processing 4 recipes in the dataJAR-recipes repo. This recipe is deprecated and will be removed in the future.</string>
+            </dict>
+        </dict>
 		<dict>
 			<key>Processor</key>
 			<string>GitHubReleasesInfoProvider</string>

--- a/Processing Foundation/Processing4.pkg.recipe
+++ b/Processing Foundation/Processing4.pkg.recipe
@@ -11,7 +11,7 @@
 	<key>MinimumVersion</key>
 	<string>2.0</string>
 	<key>ParentRecipe</key>
-	<string>com.github.jazzace.download.processing4</string>
+	<string>com.github.dataJAR-recipes.download.Processing 4</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/Processing Foundation/Processing4.pkg.recipe
+++ b/Processing Foundation/Processing4.pkg.recipe
@@ -20,17 +20,12 @@
 			<key>Arguments</key>
 			<dict>
 				<key>input_plist_path</key>
-				<string>%RECIPE_CACHE_DIR%/%NAME%/Processing.app/Contents/Info.plist</string>
+				<string>%pathname%/Processing.app/Contents/Info.plist</string>
 			</dict>
 		</dict>
 		<dict>
 			<key>Processor</key>
 			<string>AppPkgCreator</string>
-			<key>Arguments</key>
-			<dict>
-				<key>app_path</key>
-				<string>%RECIPE_CACHE_DIR%/%NAME%/Processing.app</string>
-			</dict>
 		</dict>
 	</array>
 </dict>


### PR DESCRIPTION
The info in the Processing4.download recipe in this repo is no longer accurate — the `aarch64` download is only Apple Silicon now, not Universal.

This recipe is now sufficiently identical to the equivalent recipe in dataJAR-recipes that it's worth deprecating and changing this repo's pkg parent.

Verbose recipe run output for the adjusted pkg recipe, with default (Intel) architecture:

```
% autopkg run -vvq 'jazzace-recipes/Processing Foundation/Processing4.pkg.recipe'
Processing jazzace-recipes/Processing Foundation/Processing4.pkg.recipe...
WARNING: jazzace-recipes/Processing Foundation/Processing4.pkg.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
GitHubReleasesInfoProvider
{'Input': {'asset_regex': 'processing-([0-9]+(\\.[0-9]+)+)-macos-x64.dmg$',
           'github_repo': 'processing/processing4',
           'include_prereleases': ''}}
GitHubReleasesInfoProvider: No value supplied for CURL_PATH, setting default value of: /usr/bin/curl
GitHubReleasesInfoProvider: No value supplied for GITHUB_URL, setting default value of: https://api.github.com
GitHubReleasesInfoProvider: No value supplied for GITHUB_TOKEN_PATH, setting default value of: ~/.autopkg_gh_token
GitHubReleasesInfoProvider: Matched regex 'processing-([0-9]+(\.[0-9]+)+)-macos-x64.dmg$' among asset(s): processing-4.4.10-linux-aarch64-portable.zip, processing-4.4.10-linux-aarch64.snap, processing-4.4.10-linux-x64-portable.zip, processing-4.4.10-linux-x64.snap, processing-4.4.10-macos-aarch64-portable.zip, processing-4.4.10-macos-aarch64.dmg, processing-4.4.10-macos-x64-portable.zip, processing-4.4.10-macos-x64.dmg, processing-4.4.10-reference.zip, processing-4.4.10-windows-x64-portable.zip, processing-4.4.10-windows-x64.msi
GitHubReleasesInfoProvider: Selected asset 'processing-4.4.10-macos-x64.dmg' from release 'Processing 4.4.10'
{'Output': {'asset_created_at': '2025-10-14T15:03:26Z',
            'asset_url': 'https://api.github.com/repos/processing/processing4/releases/assets/304160928',
            'release_notes': '-_- okay. :) \r\n'
                             '\r\n'
                             "## What's Changed\r\n"
                             "### What's Changed 🎊\r\n"
                             '* Rename output JARs in createLibrary tasks by '
                             '@Stefterv in '
                             'https://github.com/processing/processing4/pull/1278\r\n'
                             '\r\n'
                             '\r\n'
                             '**Full Changelog**: '
                             'https://github.com/processing/processing4/compare/processing-1309-4.4.9...processing-1310-4.4.10',
            'url': 'https://github.com/processing/processing4/releases/download/processing-1310-4.4.10/processing-4.4.10-macos-x64.dmg',
            'version': 'processing-1310-4.4.10'}}
URLDownloader
{'Input': {'url': 'https://github.com/processing/processing4/releases/download/processing-1310-4.4.10/processing-4.4.10-macos-x64.dmg'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Storing new Last-Modified header: Tue, 14 Oct 2025 15:03:44 GMT
URLDownloader: Storing new ETag header: "0x8DE0B32DE98FFCF"
URLDownloader: Downloaded ~/Library/AutoPkg/Cache/com.github.jazzace.pkg.processing4/downloads/processing-4.4.10-macos-x64.dmg
{'Output': {'download_changed': True,
            'etag': '"0x8DE0B32DE98FFCF"',
            'last_modified': 'Tue, 14 Oct 2025 15:03:44 GMT',
            'pathname': '~/Library/AutoPkg/Cache/com.github.jazzace.pkg.processing4/downloads/processing-4.4.10-macos-x64.dmg',
            'url_downloader_summary_result': {'data': {'download_path': '~/Library/AutoPkg/Cache/com.github.jazzace.pkg.processing4/downloads/processing-4.4.10-macos-x64.dmg'},
                                              'summary_text': 'The following '
                                                              'new items were '
                                                              'downloaded:'}}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
CodeSignatureVerifier
{'Input': {'input_path': '~/Library/AutoPkg/Cache/com.github.jazzace.pkg.processing4/downloads/processing-4.4.10-macos-x64.dmg/Processing.app',
           'requirement': 'identifier "org.processing.app" and anchor apple '
                          'generic and certificate '
                          '1[field.1.2.840.113635.100.6.2.6] /* exists */ and '
                          'certificate leaf[field.1.2.840.113635.100.6.1.13] '
                          '/* exists */ and certificate leaf[subject.OU] = '
                          '"6297K33652"'}}
CodeSignatureVerifier: No value supplied for deep_verification, setting default value of: True
CodeSignatureVerifier: Mounted disk image ~/Library/AutoPkg/Cache/com.github.jazzace.pkg.processing4/downloads/processing-4.4.10-macos-x64.dmg
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification not defined. Using codesign defaults...
CodeSignatureVerifier: /private/tmp/dmg.DtK1XY/Processing.app: valid on disk
CodeSignatureVerifier: /private/tmp/dmg.DtK1XY/Processing.app: satisfies its Designated Requirement
CodeSignatureVerifier: /private/tmp/dmg.DtK1XY/Processing.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
{'Output': {}}
Versioner
{'Input': {'input_plist_path': '~/Library/AutoPkg/Cache/com.github.jazzace.pkg.processing4/downloads/processing-4.4.10-macos-x64.dmg/Processing.app/Contents/Info.plist'}}
Versioner: No value supplied for plist_version_key, setting default value of: CFBundleShortVersionString
Versioner: No value supplied for skip_single_root_dir, setting default value of: False
Versioner: Mounted disk image ~/Library/AutoPkg/Cache/com.github.jazzace.pkg.processing4/downloads/processing-4.4.10-macos-x64.dmg
Versioner: Found version 4.4.10 in file ~/Library/AutoPkg/Cache/com.github.jazzace.pkg.processing4/downloads/processing-4.4.10-macos-x64.dmg/Processing.app/Contents/Info.plist
{'Output': {'version': '4.4.10'}}
AppPkgCreator
{'Input': {'version': '4.4.10'}}
AppPkgCreator: No value supplied for version_key, setting default value of: CFBundleShortVersionString
AppPkgCreator: No value supplied for force_pkg_build, setting default value of: False
AppPkgCreator: Mounted disk image ~/Library/AutoPkg/Cache/com.github.jazzace.pkg.processing4/downloads/processing-4.4.10-macos-x64.dmg
AppPkgCreator: Using path '/private/tmp/dmg.8A9fzT/Processing.app' matched from globbed '/private/tmp/dmg.8A9fzT/*.app'.
AppPkgCreator: BundleID: org.processing.app
AppPkgCreator: Copied /private/tmp/dmg.8A9fzT/Processing.app to ~/Library/AutoPkg/Cache/com.github.jazzace.pkg.processing4/payload/Applications/Processing.app
AppPkgCreator: Connecting
AppPkgCreator: Sending packaging request
AppPkgCreator: Disconnecting
{'Output': {'app_pkg_creator_summary_result': {'data': {'identifier': 'org.processing.app',
                                                        'pkg_path': '~/Library/AutoPkg/Cache/com.github.jazzace.pkg.processing4/Processing-4.4.10.pkg',
                                                        'version': '4.4.10'},
                                               'report_fields': ['identifier',
                                                                 'version',
                                                                 'pkg_path'],
                                               'summary_text': 'The following '
                                                               'packages were '
                                                               'built:'},
            'new_package_request': True,
            'version': '4.4.10'}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.jazzace.pkg.processing4/receipts/Processing4.pkg-receipt-20251026-214031.plist

The following new items were downloaded:
    Download Path                                                                                                     
    -------------                                                                                                     
    ~/Library/AutoPkg/Cache/com.github.jazzace.pkg.processing4/downloads/processing-4.4.10-macos-x64.dmg  

The following packages were built:
    Identifier          Version  Pkg Path                                                                                      
    ----------          -------  --------                                                                                      
    org.processing.app  4.4.10   ~/Library/AutoPkg/Cache/com.github.jazzace.pkg.processing4/Processing-4.4.10.pkg  
```

Verbose recipe run output for the adjusted pkg recipe, with Apple Silicon architecture:

```
% autopkg run -vvq 'jazzace-recipes/Processing Foundation/Processing4.pkg.recipe' -k DOWNLOAD_ARCHITECTURE=aarch64
Processing jazzace-recipes/Processing Foundation/Processing4.pkg.recipe...
WARNING: jazzace-recipes/Processing Foundation/Processing4.pkg.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
GitHubReleasesInfoProvider
{'Input': {'asset_regex': 'processing-([0-9]+(\\.[0-9]+)+)-macos-aarch64.dmg$',
           'github_repo': 'processing/processing4',
           'include_prereleases': ''}}
GitHubReleasesInfoProvider: No value supplied for CURL_PATH, setting default value of: /usr/bin/curl
GitHubReleasesInfoProvider: No value supplied for GITHUB_URL, setting default value of: https://api.github.com
GitHubReleasesInfoProvider: No value supplied for GITHUB_TOKEN_PATH, setting default value of: ~/.autopkg_gh_token
GitHubReleasesInfoProvider: Matched regex 'processing-([0-9]+(\.[0-9]+)+)-macos-aarch64.dmg$' among asset(s): processing-4.4.10-linux-aarch64-portable.zip, processing-4.4.10-linux-aarch64.snap, processing-4.4.10-linux-x64-portable.zip, processing-4.4.10-linux-x64.snap, processing-4.4.10-macos-aarch64-portable.zip, processing-4.4.10-macos-aarch64.dmg, processing-4.4.10-macos-x64-portable.zip, processing-4.4.10-macos-x64.dmg, processing-4.4.10-reference.zip, processing-4.4.10-windows-x64-portable.zip, processing-4.4.10-windows-x64.msi
GitHubReleasesInfoProvider: Selected asset 'processing-4.4.10-macos-aarch64.dmg' from release 'Processing 4.4.10'
{'Output': {'asset_created_at': '2025-10-14T14:58:23Z',
            'asset_url': 'https://api.github.com/repos/processing/processing4/releases/assets/304159595',
            'release_notes': '-_- okay. :) \r\n'
                             '\r\n'
                             "## What's Changed\r\n"
                             "### What's Changed 🎊\r\n"
                             '* Rename output JARs in createLibrary tasks by '
                             '@Stefterv in '
                             'https://github.com/processing/processing4/pull/1278\r\n'
                             '\r\n'
                             '\r\n'
                             '**Full Changelog**: '
                             'https://github.com/processing/processing4/compare/processing-1309-4.4.9...processing-1310-4.4.10',
            'url': 'https://github.com/processing/processing4/releases/download/processing-1310-4.4.10/processing-4.4.10-macos-aarch64.dmg',
            'version': 'processing-1310-4.4.10'}}
URLDownloader
{'Input': {'url': 'https://github.com/processing/processing4/releases/download/processing-1310-4.4.10/processing-4.4.10-macos-aarch64.dmg'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Storing new Last-Modified header: Tue, 14 Oct 2025 14:58:37 GMT
URLDownloader: Storing new ETag header: "0x8DE0B3227A8F942"
URLDownloader: Downloaded ~/Library/AutoPkg/Cache/com.github.jazzace.pkg.processing4/downloads/processing-4.4.10-macos-aarch64.dmg
{'Output': {'download_changed': True,
            'etag': '"0x8DE0B3227A8F942"',
            'last_modified': 'Tue, 14 Oct 2025 14:58:37 GMT',
            'pathname': '~/Library/AutoPkg/Cache/com.github.jazzace.pkg.processing4/downloads/processing-4.4.10-macos-aarch64.dmg',
            'url_downloader_summary_result': {'data': {'download_path': '~/Library/AutoPkg/Cache/com.github.jazzace.pkg.processing4/downloads/processing-4.4.10-macos-aarch64.dmg'},
                                              'summary_text': 'The following '
                                                              'new items were '
                                                              'downloaded:'}}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
CodeSignatureVerifier
{'Input': {'input_path': '~/Library/AutoPkg/Cache/com.github.jazzace.pkg.processing4/downloads/processing-4.4.10-macos-aarch64.dmg/Processing.app',
           'requirement': 'identifier "org.processing.app" and anchor apple '
                          'generic and certificate '
                          '1[field.1.2.840.113635.100.6.2.6] /* exists */ and '
                          'certificate leaf[field.1.2.840.113635.100.6.1.13] '
                          '/* exists */ and certificate leaf[subject.OU] = '
                          '"6297K33652"'}}
CodeSignatureVerifier: No value supplied for deep_verification, setting default value of: True
CodeSignatureVerifier: Mounted disk image ~/Library/AutoPkg/Cache/com.github.jazzace.pkg.processing4/downloads/processing-4.4.10-macos-aarch64.dmg
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification not defined. Using codesign defaults...
CodeSignatureVerifier: /private/tmp/dmg.4vyEvD/Processing.app: valid on disk
CodeSignatureVerifier: /private/tmp/dmg.4vyEvD/Processing.app: satisfies its Designated Requirement
CodeSignatureVerifier: /private/tmp/dmg.4vyEvD/Processing.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
{'Output': {}}
Versioner
{'Input': {'input_plist_path': '~/Library/AutoPkg/Cache/com.github.jazzace.pkg.processing4/downloads/processing-4.4.10-macos-aarch64.dmg/Processing.app/Contents/Info.plist'}}
Versioner: No value supplied for plist_version_key, setting default value of: CFBundleShortVersionString
Versioner: No value supplied for skip_single_root_dir, setting default value of: False
Versioner: Mounted disk image ~/Library/AutoPkg/Cache/com.github.jazzace.pkg.processing4/downloads/processing-4.4.10-macos-aarch64.dmg
Versioner: Found version 4.4.10 in file ~/Library/AutoPkg/Cache/com.github.jazzace.pkg.processing4/downloads/processing-4.4.10-macos-aarch64.dmg/Processing.app/Contents/Info.plist
{'Output': {'version': '4.4.10'}}
AppPkgCreator
{'Input': {'version': '4.4.10'}}
AppPkgCreator: No value supplied for version_key, setting default value of: CFBundleShortVersionString
AppPkgCreator: No value supplied for force_pkg_build, setting default value of: False
AppPkgCreator: Mounted disk image ~/Library/AutoPkg/Cache/com.github.jazzace.pkg.processing4/downloads/processing-4.4.10-macos-aarch64.dmg
AppPkgCreator: Using path '/private/tmp/dmg.mSMvpo/Processing.app' matched from globbed '/private/tmp/dmg.mSMvpo/*.app'.
AppPkgCreator: BundleID: org.processing.app
AppPkgCreator: Package already exists at path ~/Library/AutoPkg/Cache/com.github.jazzace.pkg.processing4/Processing-4.4.10.pkg.
AppPkgCreator: Existing package matches version and identifier, not building.
{'Output': {'version': '4.4.10'}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.jazzace.pkg.processing4/receipts/Processing4.pkg-receipt-20251026-214101.plist

The following new items were downloaded:
    Download Path                                                                                                         
    -------------                                                                                                         
    ~/Library/AutoPkg/Cache/com.github.jazzace.pkg.processing4/downloads/processing-4.4.10-macos-aarch64.dmg
```