### PR TITLE
Change i1Profiler ds/pkg parent to dataJAR's download

### DIFF
--- a/X-Rite/i1profiler.download.recipe
+++ b/X-Rite/i1profiler.download.recipe
@@ -16,9 +16,18 @@ Requires the homebysix-recipes repo.
 		<string>i1Profiler</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.5.0</string>
+	<string>1.1</string>
 	<key>Process</key>
 	<array>
+		<dict>
+			<key>Processor</key>
+			<string>DeprecationWarning</string>
+			<key>Arguments</key>
+			<dict>
+				<key>warning_message</key>
+				<string>Consider switching to the i1Profiler recipes in the dataJAR-recipes repo. This recipe is deprecated and will be removed in the future.</string>
+			</dict>
+		</dict>
 		<dict>
 			<key>Processor</key>
 			<string>SparkleUpdateInfoProvider</string>

--- a/X-Rite/i1profiler.ds.recipe
+++ b/X-Rite/i1profiler.ds.recipe
@@ -24,7 +24,7 @@ Input keys:
 	<key>MinimumVersion</key>
 	<string>0.5.0</string>
 	<key>ParentRecipe</key>
-	<string>com.github.jazzace.download.i1profiler</string>
+	<string>com.github.dataJAR-recipes.download.i1Profiler</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/X-Rite/i1profiler.pkg.recipe
+++ b/X-Rite/i1profiler.pkg.recipe
@@ -13,7 +13,7 @@ and renames the package to include the version number.
 	<key>MinimumVersion</key>
 	<string>0.5.0</string>
 	<key>ParentRecipe</key>
-	<string>com.github.jazzace.download.i1profiler</string>
+	<string>com.github.dataJAR-recipes.download.i1Profiler</string>
 	<key>Process</key>
 	<array>
 		<dict>


### PR DESCRIPTION
The i1Profiler download recipe in this repo is similar in function the one in dataJAR-recipes. This PR adjusts the i1Profiler.ds and i1Profiler.pkg parent to use dataJAR's download recipe.

This consolidation will help simplify search results and lower maintenance effort. Thank you!