### PR TITLE
Deprecate Adobe Uninstaller recipes

### DIFF
--- a/AdobeUninstaller/AdobeUninstaller.download.recipe
+++ b/AdobeUninstaller/AdobeUninstaller.download.recipe
@@ -12,9 +12,18 @@
 		<string>AdobeUninstaller</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>1.0</string>
+	<string>1.1</string>
 	<key>Process</key>
 	<array>
+		<dict>
+			<key>Processor</key>
+			<string>DeprecationWarning</string>
+			<key>Arguments</key>
+			<dict>
+				<key>warning_message</key>
+				<string>Consider switching to the AdobeUninstaller recipes in the davidbpirie-recipes repo. This recipe is deprecated and will be removed in the future.</string>
+			</dict>
+		</dict>
 		<dict>
 			<key>Processor</key>
 			<string>URLDownloader</string>


### PR DESCRIPTION
The Adobe Uninstaller recipes in this repo are similar in function to the ones in davidbpirie-recipes. Normally I would open a PR with davidbpirie to deprecate those, since yours were created first and there was no need for the duplication. However, given your call for others to adopt your recipes, I think this is a good opportunity to offload recipe maintenance onto somebody who has already shown interest.

So this PR deprecates your Adobe Uninstaller recipes and points users to davidbpirie's alternatives. Thanks for considering!